### PR TITLE
follow symlinks to find the executable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(fs_canonicalize)]
+
 use std::path::Path;
 
 #[cfg(not(test))]
@@ -5,12 +7,8 @@ fn main() {
     use std::{env, fs};
     use std::process::{self, Command};
 
-    let mut path = env::current_exe().unwrap();
-    while fs::symlink_metadata(&path).unwrap().file_type().is_symlink() {
-        let new_path = fs::read_link(&path).unwrap();
-        path = path.parent().unwrap().to_path_buf();
-        path.push(new_path);
-    }
+    let path = env::current_exe().unwrap();
+    let path = fs::canonicalize(path).unwrap();
     let path = path.parent().unwrap();
     let path = path.join("deps/");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,15 @@ use std::path::Path;
 
 #[cfg(not(test))]
 fn main() {
-    use std::env;
+    use std::{env, fs};
     use std::process::{self, Command};
 
-    let path = env::current_exe().unwrap();
+    let mut path = env::current_exe().unwrap();
+    while fs::symlink_metadata(&path).unwrap().file_type().is_symlink() {
+        let new_path = fs::read_link(&path).unwrap();
+        path = path.parent().unwrap().to_path_buf();
+        path.push(new_path);
+    }
     let path = path.parent().unwrap();
     let path = path.join("deps/");
 


### PR DESCRIPTION
The README suggests you can symlink the executable into your path, but it doesn't work. This patch follows symlinks until it finds the real executable.
