### PR TITLE
WIP: groundwork for allowing `cargo install`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ authors = [
 license = "MIT"
 readme = "README.md"
 
-[dependencies.clippy]
-git = "https://github.com/Manishearth/rust-clippy"
+[dependencies]
+clippy = {path = "clippy"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,48 +1,93 @@
-use std::path::Path;
+#![feature(rustc_private)]
 
-#[cfg(not(test))]
-fn main() {
-    use std::{env, fs};
-    use std::process::{self, Command};
+#[allow(plugin_as_library)]
+extern crate clippy;
+extern crate rustc;
+extern crate rustc_driver;
+extern crate rustc_plugin;
 
-    let path = env::current_exe().unwrap();
-    let path = fs::canonicalize(path).unwrap();
-    let path = path.parent().unwrap();
-    let path = path.join("deps");
+use rustc::session::Session;
+use rustc_driver::{driver, CompilerCalls, Compilation};
 
-    let args = wrap_args(env::args(), path);
-    let mut command = Command::new("cargo");
-    command.args(&args);
-    let mut child = command.spawn().unwrap_or_else(|e| panic!("{}", e));
-    let exit_status = child.wait().unwrap_or_else(|e| panic!("{}", e));
+struct ClippyCompilerCalls;
 
-    if let Some(code) = exit_status.code() {
-        process::exit(code);
+impl<'a> CompilerCalls<'a> for ClippyCompilerCalls {
+    fn build_controller(&mut self, _: &Session) -> driver::CompileController<'a> {
+        let mut control = driver::CompileController::basic();
+
+        control.after_parse.callback = Box::new(|state| {
+            let mut registry = rustc_plugin::registry::Registry::new(state.session, state.krate.unwrap());
+            clippy::plugin_registrar(&mut registry);
+
+            let rustc_plugin::registry::Registry { early_lint_passes, late_lint_passes, lint_groups, llvm_passes, attributes, mir_passes, .. } = registry;
+            let sess = &state.session;
+            let mut ls = sess.lint_store.borrow_mut();
+            for pass in early_lint_passes {
+                ls.register_early_pass(Some(sess), true, pass);
+            }
+            for pass in late_lint_passes {
+                ls.register_late_pass(Some(sess), true, pass);
+            }
+
+            for (name, to) in lint_groups {
+                ls.register_group(Some(sess), true, name, to);
+            }
+
+            *sess.plugin_llvm_passes.borrow_mut() = llvm_passes;
+            *sess.plugin_mir_passes.borrow_mut() = mir_passes;
+            *sess.plugin_attributes.borrow_mut() = attributes;
+        });
+        control.after_analysis.stop = Compilation::Stop;
+
+        control
     }
 }
 
-fn wrap_args<T, I, P>(it: I, clippy_path: P) -> Vec<String>
+use std::path::Path;
+
+fn main() {
+    use std::env;
+
+    let path = env::current_dir().unwrap();
+    let path = path.join("target").join("debug").join("deps");
+
+    let args = wrap_args(env::args(), path);
+    for file in std::fs::read_dir("src").expect("no `src` directory available") {
+        if let Ok(file) = file {
+            let name = file.file_name();
+            if let Some(name) = name.to_str() {
+                if name == "lib.rs" || name == "main.rs" {
+                    let mut args = args.clone();
+                    args.push(format!("src/{}", name));
+                    if name == "lib.rs" {
+                        args.push("--crate-type".to_owned());
+                        args.push("lib".to_owned());
+                    }
+                    println!("{:?}", args);
+                    rustc_driver::run_compiler(&args, &mut ClippyCompilerCalls);
+                }
+            }
+        }
+    }
+}
+
+fn wrap_args<T, I, P>(it: I, dep_path: P) -> Vec<String>
     where T: AsRef<str>,
           I: IntoIterator<Item=T>,
           P: AsRef<Path> {
 
     let it = it.into_iter();
     let mut args = vec!["rustc".to_owned()];
-    let mut has_double_hyphen = false;
 
     for arg in it.skip(2) {
         let arg = arg.as_ref().to_owned();
-        has_double_hyphen |= &arg == "--";
         args.push(arg);
     }
-
-    if !has_double_hyphen {
-        args.push("--".to_owned());
-    }
     args.push("-L".to_owned());
-    args.push(clippy_path.as_ref().to_string_lossy().into_owned());
-    args.push("-lclippy".to_owned());
-    args.push("-Zextra-plugins=clippy".to_owned());
+    args.push(dep_path.as_ref().to_string_lossy().into_owned());
+    args.push(String::from("--sysroot"));
+    args.push(format!("{}/.multirust/toolchains/nightly", std::env::var("HOME").unwrap()));
     args.push("-Zno-trans".to_owned());
+    args.push("-Dclippy");
     args
 }


### PR DESCRIPTION
This requires clippy to be statically linkable (simply removing all plugin-related configurations does this). To do this properly, clippy would need to be split into a staticlib crate and a plugin crate that uses the staticlib crate. Then cargo-clippy can use the staticlib crate

cc @Manishearth 

There's lots of hacky code in here to detect `lib.rs` and `main.rs` and it the code assumes that `cargo build` already ran (without `--release`). This will obviously be done right in case this is the way that we should go forward.

fixes #11 
