### PR TITLE
Change licence badge to blue

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ a symbolic link instead.
 
 [travis-badge]: https://img.shields.io/travis/arcnmx/cargo-clippy/master.svg?style=flat-square
 [travis]: https://travis-ci.org/arcnmx/cargo-clippy
-[license-badge]: https://img.shields.io/badge/license-MIT-lightgray.svg?style=flat-square
+[license-badge]: https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square
 [license]: https://github.com/arcnmx/cargo-clippy/blob/master/LICENSE
 [clippy]: https://github.com/Manishearth/rust-clippy
 [cargo-check]: https://github.com/rsolomo/cargo-check


### PR DESCRIPTION
Blue is the most common licence badge colour at http://shields.io, especially for MIT, so be consistent with other projects.

Grey suggests an error.

Fixes https://github.com/arcnmx/cargo-clippy/issues/18.
