### PR TITLE
Add unit tests for wrap_args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ cache:
 
 script:
     - cargo build
+    - cargo test
     - export PATH="$PATH:$TRAVIS_BUILD_DIR/target/debug"
     - cargo clippy -- -Wclippy_pedantic

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,3 +46,53 @@ fn wrap_args<T, I, P>(it: I, clippy_path: P) -> Vec<String>
     args.push("-Zno-trans".to_owned());
     args
 }
+
+#[cfg(test)]
+mod test {
+    use super::wrap_args;
+
+    #[test]
+    fn test_wrap_args_no_double_hyphen() {
+        let args = [
+            "/usr/local/bin/cargo-clippy",
+            "clippy",
+            "--lib"
+        ];
+        let actual = wrap_args(&args, "/path/to/clippy");
+        let expected = [
+            "rustc",
+            "--lib",
+            "--",
+            "-L",
+            "/path/to/clippy",
+            "-lclippy",
+            "-Zextra-plugins=clippy",
+            "-Zno-trans",
+        ];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_wrap_args_double_hyphen() {
+        let args = [
+            "/usr/local/bin/cargo-clippy",
+            "clippy",
+            "--lib",
+            "--",
+            "-Cprefer-dynamic"
+        ];
+        let actual = wrap_args(&args, "/path/to/clippy");
+        let expected = [
+            "rustc",
+            "--lib",
+            "--",
+            "-Cprefer-dynamic",
+            "-L",
+            "/path/to/clippy",
+            "-lclippy",
+            "-Zextra-plugins=clippy",
+            "-Zno-trans",
+        ];
+        assert_eq!(actual, expected);
+    }
+}


### PR DESCRIPTION
Resolves #21 and adds unit test coverage for the `wrap_args`
helper command.

Signed-off-by: Paul Osborne osbpau@gmail.com
